### PR TITLE
Use negative numbers in math

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ The other way is through the `BigInt` namespace. This keeps track on the interna
 %a.divmod(%b);
 ```
 
+`%bigNum = BigInt(50)` - returns a BigInt object that has access to the functions shown below
+`%otherBigNum = BigInt("99999999999999999999999999");` - for numbers above the 32-bit limit, you have to put them in quotation marks inside of the BigInt() function, as shown here
+
+`%bigNum.add(%otherBigNum);` - adds both numbers together
+`%bigNum.subtract(%otherBigNum);` - subtracts %otherBigNum from %bigNum (%bigNum - %otherBigNum)
+`%bigNum.multiply(%otherBigNum);` - multiplies both numbers together
+`%bigNum.divMod(%otherBigNum);` - divides %bigNum by %otherBigNum (%bigNum / %otherBigNum); the division is truncated, but you can retrieve the remainder with `$BigInt::_Remainder`, which itself is also a BigInt
+
+`%bigNum.toString();` will print the full number, no commas, nothing special.
+
+`%bigNum.equals(%otherBigNum);` - returns true if both big numbers match each other (including sign), otherwise false
+`%bigNum.greaterThanOrEqual(%otherBigNum)` - returns true if %bigNum >= %otherBigNum, otherwise false
+`%bigNum.greaterThan(%otherBigNum)` - returns true if %bigNum > %otherBigNum, otherwise false
+`%bigNum.lessThanOrEqualTo(%otherBigNum)` - returns true if %bigNum <= %otherBigNum, otherwise false
+`%bigNum.lessThan(%otherBigNum)` - returns true if %bigNum < %otherBigNum, otherwise false
+
 ## Performance
 
 The performance can be read in [perf.txt](perf.txt).

--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,3 @@
+Title: Server_BigInteger
+Author: McTwist, Permamiss
+Intended for operations done with numbers above the 32-bit integer limit by creating fake big numbers with arrays.

--- a/namecheck.txt
+++ b/namecheck.txt
@@ -1,0 +1,1 @@
+Server_BigInteger

--- a/src/array.cs
+++ b/src/array.cs
@@ -7,7 +7,7 @@
 
 
 // Create new Array object to add items to
-// Argument is an another Array that will be copied over
+// Argument is another Array that will be copied over
 function Array(%copy)
 {
 	%array = new ScriptObject()

--- a/src/bigint_core.cs
+++ b/src/bigint_core.cs
@@ -18,7 +18,7 @@ exec("./uint.cs");
 // Either use uint library or manually code in the base for each arithmetic
 $bigint::base = 1000;
 
-// Add two arrays together, a.length >= b.length
+// Add two arrays together, a.length >= b.length, only to be used with same-signed ints
 function bigint__add(%a, %b)
 {
 	// if a.toString() = 1234, then a = [234, 1]
@@ -63,6 +63,7 @@ function bigint__add(%a, %b)
 			// %r.set(1, 2);
 		%i++;
 	}
+		// %r = [233, 2]; r.toString() = 2233
 
 	if (%carry > 0)
 		%r.push(%carry); // add carry to end of new BigNum's array
@@ -104,6 +105,7 @@ function bigint__addSmall(%a, %carry)
 // Subtract two arrays, a.length >= b.length
 function bigint__subtract(%a, %b)
 {
+	
 	%a_l = %a.length();
 	%b_l = %b.length();
 	%r = Array();
@@ -375,7 +377,7 @@ function bigint__shiftLeft(%x, %n)
 }
 
 // Compare two arrays, ignoring sign
-function bigint__compareAbs(%a, %b)
+function bigint__compareAbs(%a, %b) // if |a| > |b| return 1, |a| < |b| return -1, else return 0
 {
 	if (%a.length() != %b.length())
 		return %a.length() > %b.length() ? 1 : -1;
@@ -418,7 +420,11 @@ function bigint__parseValue(%v)
 	%r = Array();
 
 	%sign = getSubStr(%v, 0, 1) $= "-";
-	if (%sign) %v = getSubStr(%v, 1, strlen(%v));
+	if (%sign)
+	{
+		%v = getSubStr(%v, 1, strlen(%v));
+		%l--;
+	}
 	%r.sign = %sign;
 	// Note: No checks for exponent or decimals
 

--- a/src/bigint_core.cs
+++ b/src/bigint_core.cs
@@ -21,6 +21,8 @@ $bigint::base = 1000;
 // Add two arrays together, a.length >= b.length
 function bigint__add(%a, %b)
 {
+	// if a.toString() = 1234, then a = [234, 1]
+	// if b.toString() = 999, then b = [999]
 	%a_l = %a.length();
 	%b_l = %b.length();
 	%r = Array();
@@ -32,20 +34,38 @@ function bigint__add(%a, %b)
 	for (%i = 0; %i < %b_l; %i++)
 	{
 		%sum = %a.get(%i) + %b.get(%i) + %carry;
+			// %sum = %a.get(0) + %b.get(0) + %carry;
+			// %sum = 234 + 999 + 0;
+			// %sum = 1233;
 		%carry = (%sum >= %base) ? 1 : 0;
+			// %carry = (1233 >= 1000) ? 1 : 0;
+			// %carry = 1;
 		%r.set(%i, %sum - %carry * %base);
+			// %r.set(0, 1233 - 1 * 1000);
+			// %r.set(0, 1233 - (1 * 1000));
+			// %r.set(0, 233);
 	}
 
-	while (%i < %a_l)
+	while (%i < %a_l) // in TorqueScript, %i resumes where it was in previous for loop
 	{
+			// %i = 1;
 		%sum = %a.get(%i) + %carry;
+			// %sum = %a.get(1) + 1;
+			// %sum = 1 + 1;
+			// %sum = 2;
 		%carry = (%sum == %base) ? 1 : 0;
+			// %carry = (2 == 1000) ? 1 : 0;
+			// %carry = 0;
 		%r.set(%i, %sum - %carry * %base);
+			// %r.set(1, 2 - 0 * 1000);
+			// %r.set(1, 2 - (0 * 1000));
+			// %r.set(1, 2 - 0);
+			// %r.set(1, 2);
 		%i++;
 	}
 
 	if (%carry > 0)
-		%r.push(%carry);
+		%r.push(%carry); // add carry to end of new BigNum's array
 	return %r;
 }
 

--- a/src/bigint_obj.cs
+++ b/src/bigint_obj.cs
@@ -42,16 +42,17 @@ function BigInt::add(%this, %v)
 {
 	%a = %this.value;
 	%b = %v.value;
-	if (%a.sign != %b.sign)
-	{
-		%b.sign = !%b.sign;
-		%value = bigint__subtract(%a, %b);
-		%b.sign = !%b.sign;
-	}
-	else
-	{
-		%value = bigint__addAny(%a, %b);
-	}
+	// if (%a.sign != %b.sign)
+	// {
+	// 	%b.sign = !%b.sign;
+	// 	%value = bigint__subtract(%a, %b);
+	// 	%b.sign = !%b.sign;
+	// }
+	// else
+	// {
+	// 	%value = bigint__addAny(%a, %b);
+	// }
+	%value = bigint__addAny(%a, %b);
 
 	return BigInt("", %value);
 }
@@ -59,18 +60,19 @@ function BigInt::add(%this, %v)
 // Subtract two integers
 function BigInt::subtract(%this, %v)
 {
-	%a = %this.value;
-	%b = %v.value;
-	if (%a.sign != %b.sign)
-	{
-		%b.sign = !%b.sign;
-		%value = bigint__add(%a, %b);
-		%b.sign = !%b.sign;
-	}
-	else
-	{
-		%value = bigint__subtract(%a, %b);
-	}
+	// %a = %this.value;
+	// %b = %v.value;
+	// if (%a.sign != %b.sign)
+	// {
+	// 	%b.sign = !%b.sign;
+	// 	%value = bigint__addAny(%a, %b);
+	// 	%b.sign = !%b.sign;
+	// }
+	// else
+	// {
+	// 	%value = bigint__subtract(%a, %b);
+	// }
+	%value = bigint__subtractAny(%a, %b);
 
 	return BigInt("", %value);
 }


### PR DESCRIPTION
Adds functionality for negative numbers to be correctly represented in results for addition, subtraction, multiplication and division. Tested and working without issue.

Example:
```cs
%x = BigInt(999);
%y = BigInt(1000);
%z = %x.subtract(%y);
echo(%z.toString());
> -1
```
Previously, this would result in `999`.